### PR TITLE
fix: more scalable code and registry

### DIFF
--- a/actions/register.ts
+++ b/actions/register.ts
@@ -3,11 +3,11 @@ import {
   Context,
   Event,
   TransactionEvent,
-  Storage,
 } from "@tenderly/actions";
 
 import { ethers } from "ethers";
 import { abi } from "./artifacts/ConditionalOrder.json";
+import { Registry } from "./registry";
 
 export const addContract: ActionFn = async (context: Context, event: Event) => {
   const transactionEvent = event as TransactionEvent;
@@ -35,33 +35,3 @@ export const addContract: ActionFn = async (context: Context, event: Event) => {
   console.log(`Updated registry: ${JSON.stringify(registry.contracts)}`);
   await registry.write();
 };
-
-export const storageKey = (network: string): string => {
-  return `CONDITIONAL_ORDER_REGISTRY_${network}`;
-};
-
-export class Registry {
-  contracts: string[];
-  storage: Storage;
-  network: string;
-
-  constructor(contracts: string[], storage: Storage, network: string) {
-    this.contracts = contracts;
-    this.storage = storage;
-    this.network = network;
-  }
-
-  public static async load(
-    context: Context,
-    network: string
-  ): Promise<Registry> {
-    const registry = await context.storage.getJson(storageKey(network));
-    return new Registry(registry.contracts || [], context.storage, network);
-  }
-
-  public async write() {
-    await this.storage.putJson(storageKey(this.network), {
-      contracts: this.contracts,
-    });
-  }
-}

--- a/actions/registry.ts
+++ b/actions/registry.ts
@@ -1,0 +1,34 @@
+import {
+    Context,
+    Storage,
+  } from "@tenderly/actions";
+
+  export const storageKey = (network: string): string => {
+    return `CONDITIONAL_ORDER_REGISTRY_${network}`;
+  };
+  
+  export class Registry {
+    contracts: string[];
+    storage: Storage;
+    network: string;
+  
+    constructor(contracts: string[], storage: Storage, network: string) {
+      this.contracts = contracts;
+      this.storage = storage;
+      this.network = network;
+    }
+  
+    public static async load(
+      context: Context,
+      network: string
+    ): Promise<Registry> {
+      const registry = await context.storage.getJson(storageKey(network));
+      return new Registry(registry.contracts || [], context.storage, network);
+    }
+  
+    public async write() {
+      await this.storage.putJson(storageKey(this.network), {
+        contracts: this.contracts,
+      });
+    }
+  }

--- a/actions/test/run_local.ts
+++ b/actions/test/run_local.ts
@@ -1,6 +1,6 @@
 import { TestBlockEvent, TestRuntime } from "@tenderly/actions-test";
 import { checkForAndPlaceOrder } from "../watch";
-import { Registry } from "../register";
+import { Registry } from "../registry";
 import { ethers } from "ethers";
 
 const main = async () => {

--- a/actions/test/test_register.ts
+++ b/actions/test/test_register.ts
@@ -4,7 +4,8 @@ import {
   TestRuntime,
 } from "@tenderly/actions-test";
 import { strict as assert } from "node:assert";
-import { addContract, storageKey } from "../register";
+import { addContract } from "../register";
+import { storageKey } from "../registry";
 
 const main = async () => {
   const testRuntime = new TestRuntime();


### PR DESCRIPTION
- Remove contracts with failing `getTradableOrder()`
- Only call CoW API with validTo in the future

Current version:
<img width="1163" alt="image" src="https://github.com/SwaprHQ/conditional-smart-orders/assets/23079677/4fdf0a5d-7089-49ab-a795-04f803f6292f">
New version:
![image](https://github.com/SwaprHQ/conditional-smart-orders/assets/23079677/0a781b97-0680-4ead-830d-644ed9577a59)
